### PR TITLE
add test to subscribe to pending transactions

### DIFF
--- a/test/3_test_pubsub.js
+++ b/test/3_test_pubsub.js
@@ -62,7 +62,7 @@ if (truffleConfig.shouldRun(__filename)) {
 }
 
 function ethSubscribePromisePendingTransactions (address) {
-  return ethSubscribePromise('pendingTransactions');
+  return ethSubscribePromise('newPendingTransactions');
 }
 
 function ethSubscribePromiseLogs (address) {


### PR DESCRIPTION
`pendingTransactions` is not implemented but I wanted to have a first test to make sure we could hit the endpoint. We had to fix web3c but now we can call the endpoint :)