### PR TITLE
Remove solidity cases from oasis-client tests

### DIFF
--- a/test/8_test_oasis_client.js
+++ b/test/8_test_oasis_client.js
@@ -7,12 +7,6 @@ if (truffleConfig.shouldRun(__filename)) {
   contract('Oasis client', async (accounts) => {
     const services = [
       {
-        idl: Counter.abi,
-        bytecode: Counter.bytecode,
-        coder: new oasis.utils.EthereumCoder(),
-        label: 'solidity'
-      },
-      {
         idl: undefined,
         bytecode: require('fs').readFileSync(
           '/workdir/tests/e2e-tests/mantle/mantle-counter/target/service/mantle-counter.wasm'
@@ -53,69 +47,61 @@ if (truffleConfig.shouldRun(__filename)) {
     gateways.forEach(gatewayConfig => {
       services.forEach(serviceConfig => {
         headers.forEach(headerConfig => {
-          // We don't support confidential solidity.
-          if (!headerConfig.header.confidential || serviceConfig.label !== 'solidity') {
-            let prefix = `${serviceConfig.label}/${gatewayConfig.label}/${headerConfig.label}`;
-            let service;
+          let prefix = `${serviceConfig.label}/${gatewayConfig.label}/${headerConfig.label}`;
+          let service;
 
-            it(`${prefix}: sets the default gateway`, () => {
-              oasis.setGateway(gatewayConfig.gateway);
+          it(`${prefix}: sets the default gateway`, () => {
+            oasis.setGateway(gatewayConfig.gateway);
+          });
+
+          it(`${prefix}: deploys a service`, async () => {
+            service = await oasis.deploy({
+              idl: serviceConfig.idl,
+              bytecode: serviceConfig.bytecode,
+              arguments: [],
+              header: headerConfig.header,
+              coder: serviceConfig.coder
             });
+          });
 
-            it(`${prefix}: deploys a service`, async () => {
-              service = await oasis.deploy({
-                idl: serviceConfig.idl,
-                bytecode: serviceConfig.bytecode,
-                arguments: [],
-                header: headerConfig.header,
-                coder: serviceConfig.coder
-              });
-            });
+          it(`${prefix}: executes an rpc`, async () => {
+            let beforeCount = await service.get_counter(gatewayConfig.options);
+            await service.increment_counter(gatewayConfig.options);
+            let afterCount = await service.get_counter(gatewayConfig.options);
+            await service.set_counter(6, gatewayConfig.options);
+            let afterSetCount = await service.get_counter(gatewayConfig.options);
+            await service.set_counter2(10, 9, gatewayConfig.options);
+            let afterSetCount2 = await service.get_counter(gatewayConfig.options);
 
-            it(`${prefix}: executes an rpc`, async () => {
-              let beforeCount = await service.get_counter(gatewayConfig.options);
-              await service.increment_counter(gatewayConfig.options);
-              let afterCount = await service.get_counter(gatewayConfig.options);
-              await service.set_counter(6, gatewayConfig.options);
-              let afterSetCount = await service.get_counter(gatewayConfig.options);
-              await service.set_counter2(10, 9, gatewayConfig.options);
-              let afterSetCount2 = await service.get_counter(gatewayConfig.options);
+            assert.equal(beforeCount, 0);
+            assert.equal(afterCount, 1);
+            assert.equal(afterSetCount, 6);
+            assert.equal(afterSetCount2, 9);
+          });
 
-              assert.equal(beforeCount, 0);
-              assert.equal(afterCount, 1);
-              assert.equal(afterSetCount, 6);
-              assert.equal(afterSetCount2, 9);
-            });
-
-            it(`${prefix}: listens for three service events`, async () => {
-              let logs = await new Promise(async resolve => {
-                let logs = [];
-                service.addEventListener('Incremented', function listener (event) {
-                  logs.push(event);
-                  if (logs.length === 3) {
-                    service.removeEventListener('Incremented', listener);
-                    resolve(logs);
-                  }
-                });
-                for (let k = 0; k < 3; k += 1) {
-                  await service.increment_counter(gatewayConfig.options);
+          it(`${prefix}: listens for three service events`, async () => {
+            let logs = await new Promise(async resolve => {
+              let logs = [];
+              service.addEventListener('Incremented', function listener (event) {
+                logs.push(event);
+                if (logs.length === 3) {
+                  service.removeEventListener('Incremented', listener);
+                  resolve(logs);
                 }
               });
-
-              for (let k = 1; k < logs.length; k += 1) {
-                // Depending upon the gateway's view, we might get the log for the previous test,
-                // so just ensure the logs received are monotonically increasing.
-                let currentCounter = logs[k].newCounter;
-                let lastCounter = logs[k - 1].newCounter;
-                // Solidity coder uses big numbers.
-                if (serviceConfig.label === 'solidity') {
-                  currentCounter = currentCounter.toNumber();
-                  lastCounter = lastCounter.toNumber();
-                }
-                assert.equal(currentCounter - lastCounter, 1);
+              for (let k = 0; k < 3; k += 1) {
+                await service.increment_counter(gatewayConfig.options);
               }
             });
-          }
+
+            for (let k = 1; k < logs.length; k += 1) {
+              // Depending upon the gateway's view, we might get the log for the previous test,
+              // so just ensure the logs received are monotonically increasing.
+              let currentCounter = logs[k].newCounter;
+              let lastCounter = logs[k - 1].newCounter;
+              assert.equal(currentCounter - lastCounter, 1);
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
This change will be required if @nhynes decides to remove https://github.com/oasislabs/oasis.js/blob/master/packages/ethereum/src/coder.ts#L14 in the update to ethers-next.