### PR TITLE
Use new oasis.js api

### DIFF
--- a/test/6_test_deploy_header.js
+++ b/test/6_test_deploy_header.js
@@ -32,7 +32,7 @@ if (truffleConfig.shouldRun(__filename)) {
           },
           ...options
         });
-        let resultantExpiry = await gateway.oasis.getExpiry(oasis.utils.bytes.toHex(instance._inner.address));
+        let resultantExpiry = await gateway.oasis.getExpiry(oasis.utils.bytes.toHex(instance.address));
         assert.equal(expectedExpiry, resultantExpiry);
       });
 


### PR DESCRIPTION
the service address was moved from `service._inner` to a public member of the `Service`, itself.